### PR TITLE
WEB-21: fix the first screen (responsive)

### DIFF
--- a/lib/screens/FirstScreen.dart
+++ b/lib/screens/FirstScreen.dart
@@ -26,32 +26,25 @@ class FirstScreen extends StatelessWidget {
       ),
       body: BlocBuilder<PickerBloc, PickerState>(
         builder: (context, pickerState) {
-          return Center(
+          return Container(
+            width: MediaQuery.of(context).size.width,
+            height: MediaQuery.of(context).size.height,
             child: Flex(
               direction: Axis.vertical,
-              mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Padding(
-                  padding: EdgeInsets.only(
-                    top: T.Spacing.medium,
-                    bottom: T.Spacing.medium,
-                  ),
-                  child: Text(
-                    'How far would you like to run?',
-                    style: _howFarStyle,
-                  ),
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                Text(
+                  'How far would you like to run?',
+                  style: _howFarStyle,
                 ),
                 Picker(
                   bloc: BlocProvider.of<PickerBloc>(context),
                   pickerValue: pickerState.pickerValue,
                 ),
                 _dropDown,
-                Container(
-                  padding: EdgeInsets.only(
-                    top: T.Spacing.large,
-                  ),
-                  child: NextButton(disabled: pickerState.pickerValue == '0.0'),
+                NextButton(
+                  disabled: pickerState.pickerValue == '0.0',
                 ),
               ],
             ),

--- a/lib/widgets/Picker.dart
+++ b/lib/widgets/Picker.dart
@@ -65,40 +65,36 @@ class _PickerState extends State<Picker> {
   Widget build(BuildContext context) {
     _initializePickers();
     final theme = Theme.of(context);
-    return Column(
-      children: <Widget>[
-        Container(
-          width: T.Spacing.xxlarge,
-          height: T.Spacing.xlarge,
-          decoration: _boxOutline,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Theme(
-                data: theme.copyWith(
-                  accentColor: brightPink,
-                  textTheme: theme.textTheme.copyWith(
-                    headline: _highlightedStyle,
-                    body1: _notHighlightedStyle,
-                  ),
-                ),
-                child: _wholeNumberPicker,
+    return Container(
+      width: T.Spacing.xxlarge,
+      height: T.Spacing.xlarge,
+      decoration: _boxOutline,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Theme(
+            data: theme.copyWith(
+              accentColor: brightPink,
+              textTheme: theme.textTheme.copyWith(
+                headline: _highlightedStyle,
+                body1: _notHighlightedStyle,
               ),
-              _dot,
-              Theme(
-                data: theme.copyWith(
-                  accentColor: brightPink,
-                  textTheme: theme.textTheme.copyWith(
-                    headline: _highlightedStyle,
-                    body1: _notHighlightedStyle,
-                  ),
-                ),
-                child: _decimalNumberPicker,
-              )
-            ],
+            ),
+            child: _wholeNumberPicker,
           ),
-        ),
-      ],
+          _dot,
+          Theme(
+            data: theme.copyWith(
+              accentColor: brightPink,
+              textTheme: theme.textTheme.copyWith(
+                headline: _highlightedStyle,
+                body1: _notHighlightedStyle,
+              ),
+            ),
+            child: _decimalNumberPicker,
+          )
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Makes sure that the buttons on the first screen do not overflow on smaller screen sizes. Also refactors the picker.

### Screenshots
#### Before
![Screen Shot 2019-10-11 at 3 01 44 PM](https://user-images.githubusercontent.com/25395806/66677721-474c0980-ec38-11e9-9390-40947c13846d.png)
#### After
![Screen Shot 2019-10-11 at 3 01 18 PM](https://user-images.githubusercontent.com/25395806/66677729-4b782700-ec38-11e9-94f5-921c58b80b8c.png)
